### PR TITLE
PSM-2321 Fix fallback to IPMI

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -21,13 +21,35 @@ const (
 )
 
 // Sleep transforms a sleep statement in a sleep-able time
-func Sleep(sleep string) (err error) {
-	sleep = strings.Replace(sleep, "sleep ", "", 1)
-	s, err := time.ParseDuration(sleep)
+func Sleep(action string) error {
+	duration, err := parserDuration(action)
 	if err != nil {
-		return fmt.Errorf("error sleeping: %v", err)
+		return err
 	}
-	time.Sleep(s)
+
+	time.Sleep(duration)
 
 	return err
+}
+
+// IsSleepAction checks if an action is the sleep action
+func IsSleepAction(action string) (bool, error) {
+	if strings.HasPrefix(action, "sleep") && strings.Contains(action, "sleep ") {
+		if _, err := parserDuration(action); err != nil {
+			return true, err
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func parserDuration(sleepAction string) (time.Duration, error) {
+	durationStr := strings.Replace(sleepAction, "sleep ", "", 1)
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parser duration in sleep action: %w", err)
+	}
+
+	return duration, nil
 }

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -1,0 +1,122 @@
+package actions
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_parserDuration(t *testing.T) {
+	type args struct {
+		sleepAction string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "1s",
+			args:    args{"sleep 1s"},
+			want:    1 * time.Second,
+			wantErr: false,
+		},
+		{
+			name:    "10m",
+			args:    args{"sleep 10m"},
+			want:    10 * time.Minute,
+			wantErr: false,
+		},
+		{
+			name:    "invalid duration: missing unit",
+			args:    args{"sleep 10"},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid duration: missing value",
+			args:    args{"sleep s"},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid action: sleep has prefix",
+			args:    args{"asleep 10s"},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid action: sleep has postfix",
+			args:    args{"sleepz 10s"},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			args:    args{""},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parserDuration(tt.args.sleepAction)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parserDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parserDuration() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSleepAction(t *testing.T) {
+	type args struct {
+		action string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "ok",
+			args:    args{"sleep 10s"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "empty",
+			args:    args{""},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "'sleep' has prefix",
+			args:    args{"asleep 10s"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "'sleep' has postfix",
+			args:    args{"sleepz 10s"},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsSleepAction(tt.args.action)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsSleepAction() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsSleepAction() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/routes/chassis.go
+++ b/routes/chassis.go
@@ -94,7 +94,7 @@ func ChassisExecuteActions(c *gin.Context) {
 	}
 	defer bmc.Close()
 
-	json := &Request{}
+	json := &request{}
 	var response []gin.H
 	if err := c.ShouldBindJSON(json); err == nil {
 		for _, action := range json.ActionSequence {
@@ -233,7 +233,7 @@ func ChassisBladeExecuteActionsByPosition(c *gin.Context) {
 	}
 	defer bmc.Close()
 
-	json := &Request{}
+	json := &request{}
 	var response []gin.H
 	if err := c.ShouldBindJSON(json); err == nil {
 		for _, action := range json.ActionSequence {
@@ -402,7 +402,7 @@ func ChassisBladeExecuteActionsBySerial(c *gin.Context) {
 		return
 	}
 
-	json := &Request{}
+	json := &request{}
 	var response []gin.H
 	if err := c.ShouldBindJSON(json); err == nil {
 		for _, action := range json.ActionSequence {

--- a/routes/host-action-executor.go
+++ b/routes/host-action-executor.go
@@ -1,0 +1,270 @@
+package routes
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bmc-toolbox/actor/internal/actions"
+	"github.com/bmc-toolbox/actor/internal/providers/ipmi"
+	"github.com/bmc-toolbox/actor/internal/screenshot"
+	"github.com/bmc-toolbox/bmclib/devices"
+	"github.com/bmc-toolbox/bmclib/discover"
+	bmcerrors "github.com/bmc-toolbox/bmclib/errors"
+	metrics "github.com/bmc-toolbox/gin-go-metrics"
+	"github.com/sirupsen/logrus"
+)
+
+type (
+	// this is abstraction over devices.Bmc and ipmi.Ipmi
+	hostBmcProvider interface {
+		Close() error
+
+		IsOn() (bool, error)
+		PowerOn() (bool, error)
+		PowerOff() (bool, error)
+		PowerCycle() (bool, error)
+		PowerCycleBmc() (bool, error)
+
+		PxeOnce() (bool, error)
+	}
+
+	hostActionExecutor struct {
+		host         string
+		username     string
+		password     string
+		isS3         bool
+		bmc          hostBmcProvider
+		screenshoter screenshot.BmcScreenshoter
+		logger       *logrus.Entry
+		actionToFn   map[string]func() (response, error)
+		plan         []planEntry
+	}
+
+	planEntry struct {
+		actionFn func() (response, error)
+		action   string
+	}
+)
+
+func newHostActionExecutor(host, username, password string, isS3 bool, logger *logrus.Entry) *hostActionExecutor {
+	e := &hostActionExecutor{
+		host:     host,
+		username: username,
+		password: password,
+		isS3:     isS3,
+		logger:   logger,
+	}
+
+	e.initActionToFunction()
+
+	return e
+}
+
+func (e *hostActionExecutor) buildExecutionPlan(actionSeq []string) error {
+	if len(actionSeq) == 0 {
+		return fmt.Errorf("action sequence is empty")
+	}
+
+	plan := make([]planEntry, 0)
+
+	for _, action := range actionSeq {
+		a := action // do not pass `action` into the function of planEntity
+
+		if fn, ok := e.actionToFn[a]; ok {
+			plan = append(plan, planEntry{fn, a})
+			continue
+		}
+
+		ok, err := actions.IsSleepAction(a)
+		if err != nil {
+			metrics.IncrCounter([]string{"errors", "bmc", "invalid_action"}, 1)
+			return fmt.Errorf("invalid action %q: %w", a, err)
+		}
+
+		if !ok {
+			metrics.IncrCounter([]string{"errors", "bmc", "unknown_action", a}, 1)
+			return fmt.Errorf("unkown action %q", a)
+		}
+
+		plan = append(plan, planEntry{func() (response, error) { return e.doSleep(a) }, a})
+	}
+
+	e.plan = plan
+
+	return nil
+}
+
+func (e *hostActionExecutor) run() ([]response, error) {
+	if len(e.plan) == 0 {
+		return nil, fmt.Errorf("execution plan is empty")
+	}
+
+	resps := make([]response, 0)
+
+	for _, entry := range e.plan {
+		resp, err := entry.actionFn()
+		resps = append(resps, resp)
+		if err != nil {
+			e.logger.WithField("action", entry.action).WithError(err).Warn("error carrying out action")
+			metrics.IncrCounter([]string{"action", "bmc", "fail", entry.action}, 1)
+			return resps, err
+		}
+
+		metrics.IncrCounter([]string{"action", "bmc", "success", entry.action}, 1)
+	}
+
+	return resps, nil
+}
+
+func (e *hostActionExecutor) initActionToFunction() {
+	e.actionToFn = map[string]func() (response, error){
+		actions.IsOn:          e.doIsOn,
+		actions.PowerOn:       e.doPowerOn,
+		actions.PowerOff:      e.doPowerOff,
+		actions.PowerCycle:    e.doPowerCycle,
+		actions.PowerCycleBmc: e.doPowerCycleBmc,
+		actions.PxeOnce:       e.doPxeOnce,
+		actions.Screenshot:    e.doScreenshot,
+	}
+}
+
+func (e *hostActionExecutor) doSleep(action string) (response, error) {
+	if err := actions.Sleep(action); err != nil {
+		return newResponse(action, false, "failed", err), err
+	}
+	return newResponse(action, true, "ok", nil), nil
+}
+
+func (e *hostActionExecutor) doScreenshot() (response, error) {
+	if err := e.setupBmc(); err != nil {
+		return newResponse(actions.Screenshot, false, "failed", err), err
+	}
+
+	if e.screenshoter == nil {
+		err := fmt.Errorf("BMC provider not found")
+		return newResponse(actions.Screenshot, false, "failed", err), err
+	}
+
+	if e.isS3 {
+		message, status, err := screenshot.S3(e.screenshoter, e.host)
+		return newResponse(actions.Screenshot, status, message, err), err
+	}
+	message, status, err := screenshot.Local(e.screenshoter, e.host)
+	return newResponse(actions.Screenshot, status, message, err), err
+}
+
+func (e *hostActionExecutor) doIsOn() (response, error) {
+	if err := e.setupHostBmcProvider(); err != nil {
+		return newResponse(actions.IsOn, false, "failed", err), err
+	}
+
+	return e.doAction(actions.IsOn, e.bmc.IsOn)
+}
+
+func (e *hostActionExecutor) doPowerOn() (response, error) {
+	if err := e.setupHostBmcProvider(); err != nil {
+		return newResponse(actions.PowerOn, false, "failed", err), err
+	}
+
+	return e.doAction(actions.PowerOn, e.bmc.PowerOn)
+}
+
+func (e *hostActionExecutor) doPowerOff() (response, error) {
+	if err := e.setupHostBmcProvider(); err != nil {
+		return newResponse(actions.PowerOff, false, "failed", err), err
+	}
+
+	return e.doAction(actions.PowerOff, e.bmc.PowerOff)
+}
+
+func (e *hostActionExecutor) doPowerCycle() (response, error) {
+	if err := e.setupHostBmcProvider(); err != nil {
+		return newResponse(actions.PowerCycle, false, "failed", err), err
+	}
+
+	return e.doAction(actions.PowerCycle, e.bmc.PowerCycle)
+}
+
+func (e *hostActionExecutor) doPowerCycleBmc() (response, error) {
+	if err := e.setupHostBmcProvider(); err != nil {
+		return newResponse(actions.PowerCycleBmc, false, "failed", err), err
+	}
+
+	return e.doAction(actions.PowerCycleBmc, e.bmc.PowerCycleBmc)
+}
+
+func (e *hostActionExecutor) doPxeOnce() (response, error) {
+	if err := e.setupHostBmcProvider(); err != nil {
+		return newResponse(actions.PxeOnce, false, "failed", err), err
+	}
+
+	return e.doAction(actions.PxeOnce, e.bmc.PxeOnce)
+}
+
+func (e *hostActionExecutor) doAction(action string, fn func() (bool, error)) (response, error) {
+	status, err := fn()
+	if err != nil {
+		return newResponse(action, status, "failed", err), err
+	}
+
+	return newResponse(action, status, "ok", nil), nil
+}
+
+// setupHostBmcProvider tries to setup a BMC provider with fallback to an IPMI
+func (e *hostActionExecutor) setupHostBmcProvider() error {
+	if err := e.setupBmc(); err != nil {
+		// fall back to IPMI
+		var errUH *bmcerrors.ErrUnsupportedHardware
+		if errors.As(err, &errUH) || errors.Is(err, bmcerrors.ErrVendorNotSupported) {
+			return e.setupIpmi()
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (e *hostActionExecutor) setupBmc() error {
+	if e.bmc != nil && e.screenshoter != nil {
+		return nil
+	}
+
+	conn, err := discover.ScanAndConnect(e.host, e.username, e.password)
+	if err != nil {
+		metrics.IncrCounter([]string{"errors", "bmc", "connect_fail"}, 1)
+		return fmt.Errorf("failed to setup BMC connection: %w", err)
+	}
+
+	if bmc, ok := conn.(devices.Bmc); ok {
+		e.bmc = bmc
+		e.screenshoter = bmc
+		return nil
+	}
+
+	return fmt.Errorf("failed to cast the BMC connection to devices.Bmc")
+}
+
+func (e *hostActionExecutor) setupIpmi() error {
+	if e.bmc != nil {
+		return nil
+	}
+
+	bmc, err := ipmi.New(e.username, e.password, e.host)
+	if err != nil {
+		metrics.IncrCounter([]string{"errors", "bmc", "ipmi_setup"}, 1)
+		return fmt.Errorf("failed to setup IPMI connection: %w", err)
+	}
+
+	e.bmc = bmc
+
+	return nil
+}
+
+func (e *hostActionExecutor) cleanup() {
+	if e.bmc != nil {
+		e.bmc.Close()
+		e.bmc = nil
+		e.screenshoter = nil
+	}
+}

--- a/routes/host.go
+++ b/routes/host.go
@@ -3,14 +3,8 @@ package routes
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/bmc-toolbox/actor/internal/actions"
-	"github.com/bmc-toolbox/actor/internal/providers/ipmi"
-	"github.com/bmc-toolbox/actor/internal/screenshot"
-	"github.com/bmc-toolbox/bmclib/devices"
-	"github.com/bmc-toolbox/bmclib/discover"
-	"github.com/bmc-toolbox/bmclib/errors"
 	metrics "github.com/bmc-toolbox/gin-go-metrics"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
@@ -19,274 +13,92 @@ import (
 
 // HostPowerStatus checks the current power status of a given host
 func HostPowerStatus(c *gin.Context) {
+	logger := log.WithFields(log.Fields{"method": "HostPowerStatus"})
+
 	host := c.Param("host")
-	if host == "" {
-		log.WithFields(
-			log.Fields{"method": "HostPowerStatus", "ip": host},
-		).Warn("Invalid host specified")
-
+	if err := validateHost(host); err != nil {
+		logger.Warn(err)
 		metrics.IncrCounter([]string{"errors", "bmc", "user_request_invalid"}, 1)
+		c.JSON(http.StatusBadRequest, newErrorResponse(err))
+		return
+	}
+	logger = log.WithFields(log.Fields{"ip": host})
 
-		c.JSON(http.StatusBadRequest, gin.H{"message": fmt.Sprintf("invalid host: %s", host)})
+	executor := newHostActionExecutor(host, viper.GetString("bmc_user"), viper.GetString("bmc_pass"), false, logger)
+	defer executor.cleanup()
+
+	if err := executor.buildExecutionPlan([]string{actions.IsOn}); err != nil {
+		c.JSON(http.StatusBadRequest, newErrorResponse(err))
 		return
 	}
 
-	conn, err := discover.ScanAndConnect(host, viper.GetString("bmc_user"), viper.GetString("bmc_pass"))
+	responses, err := executor.run()
+	if len(responses) == 0 {
+		err = fmt.Errorf("actions have been executed but no response returned: %w", err)
+		logger.WithError(err).Error("error carrying out action")
+		c.JSON(http.StatusInternalServerError, newErrorResponse(err))
+		return
+	}
+	response := responses[0]
 	if err != nil {
-		if err != errors.ErrVendorNotSupported {
-			log.WithFields(
-				log.Fields{"method": "HostPowerStatus", "operation": "discover.ScanAndConnect", "ip": host, "err": err},
-			).Warn("Failed bmc connection setup")
-
-			metrics.IncrCounter([]string{"errors", "bmc", "connect_fail"}, 1)
-
-			c.JSON(http.StatusPreconditionFailed, gin.H{"message": err.Error()})
-			return
-		}
-
-	}
-	if bmc, ok := conn.(devices.Bmc); ok {
-		defer bmc.Close()
-		status, err := bmc.IsOn()
-		if err != nil {
-			log.WithFields(
-				log.Fields{"method": "HostPowerStatus", "operation": "bmc.IsOn", "ip": host, "err": err},
-			).Warn("Error determining power status")
-
-			metrics.IncrCounter([]string{"action", "bmc", "fail", "ison"}, 1)
-
-			c.JSON(http.StatusExpectationFailed, gin.H{"action": "ison", "status": false, "message": err.Error()})
-			return
-		}
-
-		metrics.IncrCounter([]string{"action", "bmc", "success", "ison"}, 1)
-		c.JSON(http.StatusOK, gin.H{"action": "ison", "status": status, "message": "ok"})
+		c.JSON(http.StatusExpectationFailed, response)
 		return
 	}
 
-	bmc, err := ipmi.New(viper.GetString("bmc_user"), viper.GetString("bmc_pass"), host)
-	if err != nil {
-		log.WithFields(
-			log.Fields{"method": "HostPowerStatus", "operation": "ipmi.New", "ip": host, "err": err},
-		).Warn("Error setting up IPMI connection")
-
-		metrics.IncrCounter([]string{"errors", "bmc", "ipmi_setup"}, 1)
-		c.JSON(http.StatusPreconditionFailed, gin.H{"message": err.Error()})
-		return
-	}
-	status, err := bmc.IsOn()
-	if err != nil {
-		log.WithFields(
-			log.Fields{"method": "HostPowerStatus", "operation": "bmc.IsOn", "ip": host, "err": err},
-		).Warn("Error determining power status")
-
-		metrics.IncrCounter([]string{"action", "bmc", "fail", "ison"}, 1)
-		c.JSON(http.StatusExpectationFailed, gin.H{"action": "ison", "status": false, "message": err.Error()})
-		return
-	}
-
-	metrics.IncrCounter([]string{"action", "bmc", "success", "ison"}, 1)
-	c.JSON(http.StatusOK, gin.H{"action": "ison", "status": status, "message": "ok"})
+	c.JSON(http.StatusOK, response)
 }
 
 // HostExecuteActions carries out the execution of the requested action-list for a given host
 func HostExecuteActions(c *gin.Context) {
+	logger := log.WithFields(log.Fields{"method": "HostExecuteActions"})
+
 	host := c.Param("host")
-	if host == "" {
-		log.WithFields(
-			log.Fields{"method": "HostPowerStatus", "ip": host},
-		).Warn("Invalid host specified")
-
+	if err := validateHost(host); err != nil {
+		logger.Warn(err)
 		metrics.IncrCounter([]string{"errors", "bmc", "user_request_invalid"}, 1)
-
-		c.JSON(http.StatusBadRequest, gin.H{"message": fmt.Sprintf("invalid host: %s", host)})
+		c.JSON(http.StatusBadRequest, newErrorResponse(err))
 		return
 	}
+	logger = log.WithFields(log.Fields{"ip": host})
 
-	conn, err := discover.ScanAndConnect(host, viper.GetString("bmc_user"), viper.GetString("bmc_pass"))
+	req, err := unmarshalRequest(c)
 	if err != nil {
-		if err != errors.ErrVendorNotSupported {
-			log.WithFields(
-				log.Fields{"method": "HostExecuteActions", "operation": "discover.ScanAndConnect", "ip": host, "err": err},
-			).Warn("Failed bmc connection setup")
-
-			metrics.IncrCounter([]string{"action", "bmc", "success", "ison"}, 1)
-
-			c.JSON(http.StatusPreconditionFailed, gin.H{"message": err.Error()})
-			return
-		}
-
-		bmc, err := ipmi.New(viper.GetString("bmc_user"), viper.GetString("bmc_pass"), host)
-		if err != nil {
-			log.WithFields(
-				log.Fields{"method": "HostExecuteActions", "operation": "ipmi.New", "ip": host, "err": err},
-			).Warn("Error setting up IPMI connection")
-
-			metrics.IncrCounter([]string{"errors", "bmc", "ipmi_setup"}, 1)
-			c.JSON(http.StatusPreconditionFailed, gin.H{"message": err.Error()})
-			return
-		}
-
-		json := &Request{}
-		var response []gin.H
-		if err := c.ShouldBindJSON(json); err == nil {
-			for _, action := range json.ActionSequence {
-				if strings.HasPrefix(action, "sleep") {
-					err := actions.Sleep(action)
-					if err != nil {
-						response = append(response, gin.H{"action": action, "status": false, "error": err.Error()})
-
-						metrics.IncrCounter([]string{"action", "bmc", "fail", "sleep"}, 1)
-						c.JSON(http.StatusExpectationFailed, response)
-						return
-					}
-
-					metrics.IncrCounter([]string{"action", "bmc", "success", "sleep"}, 1)
-					response = append(response, gin.H{"action": action, "status": true, "message": "ok"})
-					continue
-				}
-
-				var status bool
-				switch action {
-				case actions.PowerCycle:
-					status, err = bmc.PowerCycle()
-				case actions.IsOn:
-					status, err = bmc.IsOn()
-				case actions.PxeOnce:
-					status, err = bmc.PxeOnce()
-				case actions.PowerCycleBmc:
-					status, err = bmc.PowerCycleBmc()
-				case actions.PowerOn:
-					status, err = bmc.PowerOn()
-				case actions.PowerOff:
-					status, err = bmc.PowerOff()
-				default:
-					response = append(response, gin.H{"action": action, "error": "unknown action"})
-					log.WithFields(
-						log.Fields{"method": "HostExecuteActions", "ip": host, "action": action},
-					).Warn("Unknown action")
-
-					metrics.IncrCounter([]string{"errors", "bmc", "unknown_action"}, 1)
-
-					c.JSON(http.StatusBadRequest, response)
-					return
-				}
-
-				if err != nil {
-					log.WithFields(
-						log.Fields{"method": "HostExecuteActions", "ip": host, "action": action, "err": err.Error()},
-					).Warn("Error carrying out action")
-
-					metrics.IncrCounter([]string{"action", "bmc", "fail", action}, 1)
-
-					response = append(response, gin.H{"action": action, "status": status, "error": err.Error()})
-					c.JSON(http.StatusExpectationFailed, response)
-					return
-				}
-
-				metrics.IncrCounter([]string{"action", "bmc", "success", action}, 1)
-				response = append(response, gin.H{"action": action, "status": status, "message": "ok"})
-			}
-		} else {
-			log.WithFields(
-				log.Fields{"method": "HostExecuteActions", "ip": host, "err": err.Error()},
-			).Warn("Malformed request")
-
-			metrics.IncrCounter([]string{"errors", "bmc", "user_request_invalid"}, 1)
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-
-		c.JSON(http.StatusOK, response)
+		logger.WithError(err).Error("failed to unmarshal request")
+		c.JSON(http.StatusBadRequest, newErrorResponse(fmt.Errorf("failed to unmarshal request: %w", err)))
 		return
 	}
 
-	if bmc, ok := conn.(devices.Bmc); ok {
-		defer bmc.Close()
-		json := &Request{}
-		var response []gin.H
-		if err := c.ShouldBindJSON(json); err == nil {
-			for _, action := range json.ActionSequence {
-				if strings.HasPrefix(action, "sleep") {
-					err := actions.Sleep(action)
-					if err != nil {
+	executor := newHostActionExecutor(
+		host, viper.GetString("bmc_user"), viper.GetString("bmc_pass"), viper.GetBool("s3.enabled"), logger,
+	)
+	defer executor.cleanup()
 
-						metrics.IncrCounter([]string{"action", "bmc", "fail", action}, 1)
-						response = append(response, gin.H{"action": action, "status": false, "error": err.Error()})
-						c.JSON(http.StatusExpectationFailed, response)
-						return
-					}
-
-					metrics.IncrCounter([]string{"action", "bmc", "success", action}, 1)
-					response = append(response, gin.H{"action": action, "status": true, "message": "ok"})
-					continue
-				}
-
-				var status bool
-				message := "ok"
-				switch action {
-				case actions.PowerCycle:
-					status, err = bmc.PowerCycle()
-				case actions.IsOn:
-					status, err = bmc.IsOn()
-				case actions.PxeOnce:
-					status, err = bmc.PxeOnce()
-				case actions.PowerCycleBmc:
-					status, err = bmc.PowerCycleBmc()
-				case actions.PowerOn:
-					status, err = bmc.PowerOn()
-				case actions.PowerOff:
-					status, err = bmc.PowerOff()
-				case actions.Screenshot:
-					if viper.GetBool("s3.enabled") {
-						message, status, err = screenshot.S3(bmc, host)
-					} else {
-						message, status, err = screenshot.Local(bmc, host)
-					}
-				default:
-					response = append(response, gin.H{"action": action, "error": "unknown action"})
-					log.WithFields(
-						log.Fields{"method": "HostExecuteActions", "ip": host, "action": action},
-					).Warn("Unknown action")
-
-					metrics.IncrCounter([]string{"errors", "bmc", "unknown_action", action}, 1)
-					c.JSON(http.StatusBadRequest, response)
-					return
-				}
-
-				if err != nil {
-					log.WithFields(
-						log.Fields{"method": "HostExecuteActions", "ip": host, "action": action, "err": err.Error()},
-					).Warn("Error carrying out action")
-
-					metrics.IncrCounter([]string{"action", "bmc", "fail", action}, 1)
-
-					response = append(response, gin.H{"action": action, "status": status, "error": err.Error()})
-					c.JSON(http.StatusExpectationFailed, response)
-					return
-				}
-
-				metrics.IncrCounter([]string{"action", "bmc", "success", action}, 1)
-				response = append(response, gin.H{"action": action, "status": status, "message": message})
-			}
-		} else {
-			log.WithFields(
-				log.Fields{"method": "HostExecuteActions", "ip": host, "err": err.Error()},
-			).Warn("Bad request")
-
-			metrics.IncrCounter([]string{"errors", "bmc", "user_request_invalid"}, 1)
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-
-		c.JSON(http.StatusOK, response)
+	if err := executor.buildExecutionPlan(req.ActionSequence); err != nil {
+		c.JSON(http.StatusBadRequest, newErrorResponse(err))
 		return
 	}
 
-	log.WithFields(
-		log.Fields{"method": "HostExecuteActions", "ip": host},
-	).Warn("Unknown device or vendor")
+	response, err := executor.run()
+	if err != nil {
+		c.JSON(http.StatusExpectationFailed, response)
+		return
+	}
 
-	metrics.IncrCounter([]string{"errors", "bmc", "unsupported_hardware"}, 1)
-	c.JSON(http.StatusPreconditionFailed, gin.H{"message": "unknown device or vendor"})
+	c.JSON(http.StatusOK, response)
+	return
+}
+
+func validateHost(host string) error {
+	if host == "" {
+		return fmt.Errorf("invalid host: %s", host)
+	}
+	return nil
+}
+
+func unmarshalRequest(c *gin.Context) (*request, error) {
+	req := &request{}
+	if err := c.ShouldBindJSON(req); err != nil {
+		return nil, err
+	}
+	return req, nil
 }

--- a/routes/request.go
+++ b/routes/request.go
@@ -1,7 +1,7 @@
 package routes
 
-// Request describes the action to be carried out by actor
-type Request struct {
+// request describes the action to be carried out by actor
+type request struct {
 	ActionSequence []string `json:"action-sequence"`
 	CallbackURL    string   `json:"callback-url"`
 }

--- a/routes/response.go
+++ b/routes/response.go
@@ -1,0 +1,34 @@
+package routes
+
+// response represents an action response
+type response struct {
+	Action  string `json:"action"`
+	Status  bool   `json:"status"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+// errorResponse represents not an action error, i.e. BadRequest, StatusPreconditionFailed
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func newResponse(action string, status bool, message string, err error) response {
+	resp := response{
+		Action:  action,
+		Status:  status,
+		Message: message,
+		Error:   "",
+	}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	return resp
+}
+
+func newErrorResponse(err error) errorResponse {
+	// if err is nil it is a mistake in the code, do not return it as an error to a user
+	return errorResponse{
+		Error: err.Error(),
+	}
+}


### PR DESCRIPTION
This changes fix fallback to IPMI and move the execution of actions to dedicated component.
 
Test both version before this changes and after 
```
➜  # power status
➜  curl -s localhost:8080/host/10.193.251.108
{"action":"ison","message":"ok","status":true}
➜  curl -s localhost:8081/host/10.193.251.108
{"action":"ison","status":true,"message":"ok","error":""}
➜  

➜  # ison
➜  curl -s -d '{"action-sequence": ["ison"]}' localhost:8080/host/10.193.251.108
[{"action":"ison","message":"ok","status":true}]
➜  curl -s -d '{"action-sequence": ["ison"]}' localhost:8081/host/10.193.251.108
[{"action":"ison","status":true,"message":"ok","error":""}]
➜  

➜  # sleep 1s
➜  curl -s -d '{"action-sequence": ["sleep 1s"]}' localhost:8080/host/10.193.251.108
[{"action":"sleep 1s","message":"ok","status":true}]
➜  curl -s -d '{"action-sequence": ["sleep 1s"]}' localhost:8081/host/10.193.251.108
[{"action":"sleep 1s","status":true,"message":"ok","error":""}]
➜  

➜  # sleep 1s, ison
➜  curl -s -d '{"action-sequence": ["sleep 1s", "ison"]}' localhost:8080/host/10.193.251.108
[{"action":"sleep 1s","message":"ok","status":true},{"action":"ison","message":"ok","status":true}]            
➜  curl -s -d '{"action-sequence": ["sleep 1s", "ison"]}' localhost:8081/host/10.193.251.108
[{"action":"sleep 1s","status":true,"message":"ok","error":""},{"action":"ison","status":true,"message":"ok","error":""}]
➜  

➜  # unknown action 
➜  curl -s -d '{"action-sequence": ["unknown"]}' localhost:8080/host/10.193.251.108
[{"action":"unknown","error":"unknown action"}]
➜  curl -s -d '{"action-sequence": ["unknown"]}' localhost:8081/host/10.193.251.108
{"error":"unknown action \"unknown\""}
➜  

➜  # fallback to ipmi
➜  curl -s -d '{"action-sequence": ["ison"]}' localhost:8080/host/10.193.182.183        
{"message":"Hardware not supported: quanta hardware not supported"}%                                                           ➜  curl -s -d '{"action-sequence": ["ison"]}' localhost:8081/host/10.193.182.183
[{"action":"ison","status":false,"message":"failed","error":"failed to setup IPMI connection: unable to find binary: ipmitool"}]
➜  
```