### PR TITLE
Use the correct ipmitool binary name

### DIFF
--- a/internal/providers/ipmi/ipmi.go
+++ b/internal/providers/ipmi/ipmi.go
@@ -22,7 +22,7 @@ func New(host string, username string, password string) (*Ipmi, error) {
 		Host:     host,
 	}
 
-	ipmitoolBin, err := ipmi.findBin("ipmitoolBin")
+	ipmitoolBin, err := ipmi.findBin("ipmitool")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It is `ipmitool` and not `ipmitoolBin`. This should solve the "failed to
setup IPMI connection: unable to find binary: ipmitoolBin" error that
happens when we fall back to use IPMI.