### PR TITLE
Return no error on successful IPMI

### DIFF
--- a/internal/providers/server-bmc-wrapper.go
+++ b/internal/providers/server-bmc-wrapper.go
@@ -144,6 +144,7 @@ func (w *ServerBmcWrapper) createBmcProviderWithFallback() error {
 			return ipmiErr
 		}
 		w.bmc = ipmiProvider
+		return nil
 	}
 
 	return err


### PR DESCRIPTION
We try to setup a BMC connection first. If we fail, we try to fall back
to IPMI but we were returning the BMC error ("failed to setup BMC
connection: Hardware not supported") if the IPMI connection was
successful.